### PR TITLE
Clean up daemon thread on broken Ghost call.

### DIFF
--- a/ghost/test/testcases.py
+++ b/ghost/test/testcases.py
@@ -57,9 +57,17 @@ class LiveServerTestCase(LiveServerTestCase, TestCase):
         except ImportError:
             pass
         super(LiveServerTestCase, cls).setUpClass()
+
         # Server is up and running, start up a Ghost instance.
         if not hasattr(cls, 'ghost'):
-            cls.ghost = Ghost(display=cls.display, wait_timeout=cls.wait_timeout, log_level=cls.log_level)
+            try:
+                cls.ghost = Ghost(display=cls.display, wait_timeout=cls.wait_timeout, log_level=cls.log_level)
+            except:
+                # If we fail to initialize a Ghost instance, we should
+                # still clean up any daemon threads the parent
+                # LiveServerTestCase made.
+                super(LiveServerTestCase, cls).tearDownClass()
+                raise
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Example problem:

```
$ REUSE_DB=1 ./manage test \
    voipgrid.base.permission.tests.test_views.TestPermissionViews \
    voipgrid.utils.test_net
```

Results in:

```
File ".../ghost/ghost.py",
  line 335, in __init__
    raise Exception("Ghost.py requires PyQT5")
Exception: Ghost.py requires PyQT5
```

Which is ok. But this isn't:

```
FAIL: get_tcp_in_use(pid) should return the TCP listening sockets.
...
AssertionError: Lists differ: [(0, 65409), (16777343, 9000)] !=
                              [(0, 65409)]
```

Which means that Ghost test was leaking a server daemon process.

Fix against 1.0.2 is:

```
--- ghost/test/testcases.py.orig    2015-08-21 12:29:59.687005129 +0200
+++ ghost/test/testcases.py 2015-08-21 12:30:02.362916706 +0200
@@ -97,7 +97,12 @@ class LiveServerTestCase(LiveServerTestC

         # Server is up and running, start up a Ghost instance.
         if not hasattr(cls, 'ghost'):
-            cls.ghost = Ghost(display=cls.display, wait_timeout=cls.wait_timeout, log_level=cls.log_level)
+            try:
+                cls.ghost = Ghost(display=cls.display, wait_timeout=cls.wait_timeout, log_level=cls.log_level)
+            except:
+                if hasattr(cls, 'server_thread'):
+                    cls.server_thread.join()
+                raise

     @classmethod
     def tearDownClass(cls):
```
