### PR TITLE
Correct missing Xvfb teardown introduced by d60fa21f changes.

### DIFF
--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -674,7 +674,7 @@ class Ghost(object):
         del self.manager
         del self.page
         del self.main_frame
-        if hasattr(self, 'xvfb'):
+        if hasattr(self, 'vdisplay'):
             self.logger.debug('Terminating xvfb.')
             self.vdisplay.stop()
 


### PR DESCRIPTION
The change would leave Xvfb processes running. This fixes it.
